### PR TITLE
support "key" attr for card

### DIFF
--- a/src/components/Workspace/helpers.js
+++ b/src/components/Workspace/helpers.js
@@ -10,7 +10,7 @@ export function useKeyWithChildren(_children) {
 
   const children = useMemo(() =>
     childrenArray.map((childComponent, index) => (
-      <Card key={index + 1}>{React.cloneElement(childComponent)}</Card>
+      <Card key={childComponent.key ?? index + 1}>{React.cloneElement(childComponent)}</Card>
     )), [childrenArray]);
   return children;
 }


### PR DESCRIPTION
In react-grid-layout "i" is the string corresponding to the component key.
If the key is set, the card will be associated with it. 

Or instead of the "key" attribute, for compatibility, you can add the "i" attribute.