### PR TITLE
Made resource layout responsive 

### DIFF
--- a/__tests__/workspace.spec.js
+++ b/__tests__/workspace.spec.js
@@ -6,24 +6,6 @@ import Card from './utils/Card';
 
 configure({ adapter: new Adapter() });
 
-const absoluteLayout = [
-  {
-    'w':6, 'h':1, 'x':0, 'y':0, 'i': 'card_0',
-  },
-  {
-    'w':6, 'h':1, 'x':6, 'y':2, 'i': 'card_1',
-  },
-  {
-    'w':6, 'h':1, 'x':0, 'y':2, 'i': 'card_2',
-  },
-  {
-    'w':6, 'h':1, 'x':6, 'y':0, 'i': 'card_3',
-  },
-  {
-    'w':12, 'h':1, 'x':0, 'y':1, 'i': 'card_4',
-  },
-];
-
 const test_layout = {
   // this line is for relative positioning
   widths: [[1, 1], [1, 1], [1]],
@@ -54,13 +36,6 @@ describe('testing Workspace', () => {
     };
     let found = false;
     generateLayoutTest(initialLayout, 3, found, done);
-  });
-
-  it('test absolute layout', done => {
-    const match = absoluteLayout;
-    const initialLayout = { absolute: absoluteLayout };
-    let found = false;
-    generateLayoutTest(initialLayout, absoluteLayout.length, found, done, match);
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-workspace-rcl",
-  "version": "0.7.1-rc7",
+  "version": "0.7.1-rc8",
   "main": "dist",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-workspace-rcl",
-  "version": "0.7.1-rc2",
+  "version": "0.7.1-rc3",
   "main": "dist",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-workspace-rcl",
-  "version": "0.7.1-rc18",
+  "version": "0.7.1-rc19",
   "main": "dist",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-workspace-rcl",
-  "version": "0.7.1-rc15",
+  "version": "0.7.1-rc16",
   "main": "dist",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-workspace-rcl",
-  "version": "0.7.0-rc3",
+  "version": "0.7.0",
   "main": "dist",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-workspace-rcl",
-  "version": "0.7.1-rc12",
+  "version": "0.7.1-rc13",
   "main": "dist",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-workspace-rcl",
-  "version": "0.7.1-rc4",
+  "version": "0.7.1-rc5",
   "main": "dist",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-workspace-rcl",
-  "version": "0.7.1-rc9",
+  "version": "0.7.1-rc10",
   "main": "dist",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-workspace-rcl",
-  "version": "0.7.1-rc21",
+  "version": "0.7.1-rc22",
   "main": "dist",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-workspace-rcl",
-  "version": "0.7.1-rc11",
+  "version": "0.7.1-rc12",
   "main": "dist",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-workspace-rcl",
-  "version": "0.7.1-rc22",
+  "version": "1.0.0-rc0",
   "main": "dist",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-workspace-rcl",
-  "version": "0.7.1-rc20",
+  "version": "0.7.1-rc21",
   "main": "dist",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-workspace-rcl",
-  "version": "0.7.1-rc0",
+  "version": "0.7.1-rc1",
   "main": "dist",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-workspace-rcl",
-  "version": "0.7.1-rc3",
+  "version": "0.7.1-rc4",
   "main": "dist",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-workspace-rcl",
-  "version": "0.7.1-rc17",
+  "version": "0.7.1-rc18",
   "main": "dist",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-workspace-rcl",
-  "version": "0.7.1-rc13",
+  "version": "0.7.1-rc14",
   "main": "dist",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-workspace-rcl",
-  "version": "0.7.1-rc1",
+  "version": "0.7.1-rc2",
   "main": "dist",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-workspace-rcl",
-  "version": "0.7.0",
+  "version": "0.7.1-rc0",
   "main": "dist",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-workspace-rcl",
-  "version": "0.7.1-rc10",
+  "version": "0.7.1-rc11",
   "main": "dist",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-workspace-rcl",
-  "version": "0.7.1-rc16",
+  "version": "0.7.1-rc17",
   "main": "dist",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-workspace-rcl",
-  "version": "0.7.1-rc14",
+  "version": "0.7.1-rc15",
   "main": "dist",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-workspace-rcl",
-  "version": "0.7.1-rc5",
+  "version": "0.7.1-rc6",
   "main": "dist",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-workspace-rcl",
-  "version": "0.7.1-rc8",
+  "version": "0.7.1-rc9",
   "main": "dist",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-workspace-rcl",
-  "version": "0.7.1-rc6",
+  "version": "0.7.1-rc7",
   "main": "dist",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resource-workspace-rcl",
-  "version": "0.7.1-rc19",
+  "version": "0.7.1-rc20",
   "main": "dist",
   "scripts": {
     "test": "jest",

--- a/src/components/Workspace/Workspace.md
+++ b/src/components/Workspace/Workspace.md
@@ -18,29 +18,32 @@ const useStyles = makeStyles(() => ({
   dragIndicator: {},
 }));
 
-const absoluteLayout = [
-  {"w":6,"h":1,"x":0,"y":0,"i":"1"},
-  {"w":6,"h":1,"x":6,"y":2,"i":"2"},
-  {"w":6,"h":1,"x":0,"y":2,"i":"3"},
-  {"w":6,"h":1,"x":6,"y":0,"i":"4"},
-  {"w":12,"h":1,"x":0,"y":1,"i":"5"},
-];
-
 const layout = {
-  // this line is for relative positioning
-  widths: [[1, 1], [1, 1], [1]],
-  // uncomment following line to do absolute positioning, for example to restore last saved position
-  // absolute: absoluteLayout,
+  lg: [
+    {"w":6,"h":1,"x":0,"y":0,"i":"1"},
+    {"w":6,"h":1,"x":6,"y":2,"i":"2"},
+    {"w":6,"h":1,"x":0,"y":2,"i":"3"},
+    {"w":6,"h":1,"x":6,"y":0,"i":"4"},
+    {"w":12,"h":1,"x":0,"y":1,"i":"5"},
+  ]
 };
 
-function onLayoutChange(layout) {
-  // in this method you could save current layout in local storage and later restore on refresh
-  console.log(`onLayoutChange: new resource layout: ${JSON.stringify(layout)}`);
+function onLayoutChange(_layout, layouts) {
+  console.log({ _layout, layouts })
+  // in this method you could save current layouts in local storage and later restore on refresh
+  console.log(`onLayoutChange: new resource layouts: ${JSON.stringify(layouts)}`);
 }
 
 const classes = useStyles();
+const layoutWidths = [[1, 1], [1, 1], [1]];
 
-<Workspace gridMargin={[15, 15]} classes={classes} layout={layout} onLayoutChange={onLayoutChange}>
+<Workspace
+  gridMargin={[15, 15]}
+  classes={classes}
+  layout={layout}
+  onLayoutChange={onLayoutChange}
+  layoutWidths={layoutWidths}
+>
   <Card title="translationWords" classes={classes}>
     1
   </Card>

--- a/src/components/Workspace/helpers.js
+++ b/src/components/Workspace/helpers.js
@@ -54,7 +54,9 @@ export function getHeight(layoutHeights, ridx, cidx) {
 }
 
 export function generateLayouts(layoutWidths, layoutHeights, maxGridUnits, minW, minH) {
-  let layouts = [];
+  const layouts = [];
+  const smLayouts = [];
+  const xsLayouts = [];
 
   layoutWidths.forEach((row, ridx) => {
     row.forEach((cellUnit, cidx) => {
@@ -68,18 +70,44 @@ export function generateLayouts(layoutWidths, layoutHeights, maxGridUnits, minW,
         h: getHeight(layoutHeights, ridx, cidx),
       };
 
+      const smLayout = {
+        i: String(layouts.length + 1),
+        x,
+        y: ridx * (6 / layoutWidths.length),
+        w: minW,
+        h: getHeight(layoutHeights, ridx, cidx),
+      };
+
+      const xsLayout = {
+        i: String(layouts.length + 1),
+        x,
+        y: ridx * (6 / layoutWidths.length),
+        w: minW,
+        h: getHeight(layoutHeights, ridx, cidx),
+      };
+
       if (minW) {
         _layout.minW = minW;
+        xsLayout.minW = minW;
+        smLayout.minW = minW;
       }
 
       if (minH) {
         _layout.minH = minH;
+        xsLayout.minH = minH;
+        smLayout.minH = minH;
       }
 
+      xsLayouts.push(xsLayout);
+      smLayouts.push(smLayout);
       layouts.push(_layout);
     });
   });
+
   return {
-    lg: layouts, md: layouts, sm: layouts,
+    lg: layouts,
+    md: layouts,
+    sm: smLayouts,
+    xs: xsLayouts,
   };
 }

--- a/src/components/Workspace/index.js
+++ b/src/components/Workspace/index.js
@@ -42,9 +42,9 @@ export default function Workspace({
   const columns = _columns || {
     lg: totalGridUnits,
     md: totalGridUnits,
-    sm: totalGridUnits,
-    xs: totalGridUnits,
-    xxs: totalGridUnits,
+    sm: 6,
+    xs: 4,
+    xxs: 2,
   };
   const dragHandleClass = classes.dragIndicator;
   return (

--- a/src/components/Workspace/index.js
+++ b/src/components/Workspace/index.js
@@ -23,25 +23,22 @@ export default function Workspace({
   minW,
   minH,
 }) {
-  // const {
-  //   widths: layoutWidths,
-  //   heights: layoutHeights = 1,
-  //   absolute: layoutAbsolute,
-  //   minW,
-  //   minH,
-  // } = layout;
   let layouts;
 
   if (layout) {
-    // layouts = {
-    //   lg: layoutAbsolute,
-    //   md: layoutAbsolute,
-    //   sm: layoutAbsolute,
-    // };
-
     // Breaking change: After v1.0.0 layout was changed from array to object to allow each breakpoint
     // to have its own layout settings. Thus, the code below migrates the old layout prop to the new format.
     if (Array.isArray(layout)) {
+      // Add minimum width & minimum height if it isn't defined.
+      if (!layout[0]?.minW || !layout[0]?.minH) {
+        const newCurrentLayout = layout.map(l => {
+          l.minW = layout.minW;
+          l.minH = layout.minH;
+          return l;
+        });
+        layout = newCurrentLayout;
+      }
+
       layouts = generateLayouts(layoutWidths, layoutHeights, totalGridUnits, minW, minH);
       layouts = {
         ...layouts, lg: layout, md: layout,
@@ -61,12 +58,6 @@ export default function Workspace({
     xs: minW || 4,
     xxs: minW || 2,
   };
-
-  console.log({
-    columns,
-    breakpoints,
-  });
-
   const dragHandleClass = classes.dragIndicator;
 
   return (

--- a/src/components/Workspace/index.js
+++ b/src/components/Workspace/index.js
@@ -18,22 +18,37 @@ export default function Workspace({
   classes,
   resizeHandle,
   onLayoutChange,
+  layoutWidths,
+  layoutHeights,
+  minW,
+  minH,
 }) {
-  const {
-    widths: layoutWidths,
-    heights: layoutHeights = 1,
-    absolute: layoutAbsolute,
-    minW,
-    minH,
-  } = layout;
+  // const {
+  //   widths: layoutWidths,
+  //   heights: layoutHeights = 1,
+  //   absolute: layoutAbsolute,
+  //   minW,
+  //   minH,
+  // } = layout;
   let layouts;
 
-  if (layoutAbsolute) {
-    layouts = {
-      lg: layoutAbsolute,
-      md: layoutAbsolute,
-      sm: layoutAbsolute,
-    };
+  if (layout) {
+    // layouts = {
+    //   lg: layoutAbsolute,
+    //   md: layoutAbsolute,
+    //   sm: layoutAbsolute,
+    // };
+
+    // Breaking change: After v1.0.0 layout was changed from array to object to allow each breakpoint
+    // to have its own layout settings. Thus, the code below migrates the old layout prop to the new format.
+    if (Array.isArray(layout)) {
+      layouts = generateLayouts(layoutWidths, layoutHeights, totalGridUnits, minW, minH);
+      layouts = {
+        ...layouts, lg: layout, md: layout,
+      };
+    } else {
+      layouts = { ...layout };
+    }
   } else {
     layouts = generateLayouts(layoutWidths, layoutHeights, totalGridUnits, minW, minH);
   }
@@ -43,15 +58,22 @@ export default function Workspace({
     lg: totalGridUnits,
     md: totalGridUnits,
     sm: 6,
-    xs: 4,
-    xxs: 2,
+    xs: minW || 4,
+    xxs: minW || 2,
   };
+
+  console.log({
+    columns,
+    breakpoints,
+  });
+
   const dragHandleClass = classes.dragIndicator;
+
   return (
     <Container
-      dragBackgroundColor={dragBackgroundColor}
       style={style}
       classes={classes.root}
+      dragBackgroundColor={dragBackgroundColor}
     >
       <ResponsiveGridLayout
         resizeHandle={resizeHandle || ''}
@@ -79,10 +101,6 @@ Workspace.defaultProps = {
     xs: 480,
     xxs: 0,
   },
-  layout: {
-    widths: [[1]],
-    heights: [[1]],
-  },
   rowHeight: 100,
   children: [],
   dragBackgroundColor: 'transparent',
@@ -93,17 +111,6 @@ Workspace.defaultProps = {
 };
 
 Workspace.propTypes = {
-  layout: PropTypes.shape({
-    widths: PropTypes.array,
-    heights: PropTypes.oneOfType([
-      PropTypes.arrayOf(PropTypes.number),
-      PropTypes.arrayOf(PropTypes.array),
-      PropTypes.number,
-    ]),
-    absolute: PropTypes.array,
-    minW: PropTypes.number,
-    minH: PropTypes.number,
-  }),
   /** The items rendered inside the component */
   children: PropTypes.array.isRequired,
   style: PropTypes.object,
@@ -130,4 +137,13 @@ Workspace.propTypes = {
   classes: PropTypes.object,
   resizeHandle: PropTypes.instanceOf(React.Component),
   onLayoutChange: PropTypes.func,
+  layout: PropTypes.array,
+  layoutWidths: PropTypes.array,
+  layoutHeights: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.number),
+    PropTypes.arrayOf(PropTypes.array),
+    PropTypes.number,
+  ]),
+  minW: PropTypes.number,
+  minH: PropTypes.number,
 };

--- a/src/components/Workspace/index.js
+++ b/src/components/Workspace/index.js
@@ -94,6 +94,8 @@ Workspace.defaultProps = {
   },
   rowHeight: 100,
   children: [],
+  layoutWidths: [[1]],
+  layoutHeights: [[1]],
   dragBackgroundColor: 'transparent',
   classes: {
     root: {},


### PR DESCRIPTION
# Describe what your pull request addresses

- [ ]

## Test Instructions

- [x] Open https://deploy-preview-199--gateway-edit.netlify.app/
- [x] Change your window width to 900px the layout should adjust and no card content should overflow the card.
- [x] If you change the layout it should persist for that window size (681px - 900px)
- [x] Now reduce the width down below 680px
- [x] The layout should rearrange based on the window size. Changing the layout should be persisted for this window size (0px - 680px)
- [x] Replace the contents of `[USERNAME]_resourceLayout` in localstorage for `https://deploy-preview-199--gateway-edit.netlify.app/` with the contents of `[USERNAME]_resourceLayout` in https://gateway-edit.netlify.app/ 
- [x] It should maintain the same layout but only when the window size is 900px or above. 
- [ ] Verify that the styleguidist demo is still working: https://deploy-preview-15--resource-workspace.netlify.app/
